### PR TITLE
added self to make_anchors

### DIFF
--- a/yolov8_from_scratch.ipynb
+++ b/yolov8_from_scratch.ipynb
@@ -967,7 +967,7 @@
     "        return torch.cat(tensors=(box * strides, cls.sigmoid()), dim=1)\n",
     "\n",
     "\n",
-    "    def make_anchors(x, strides, offset=0.5):\n",
+    "    def make_anchors(self, x, strides, offset=0.5):\n",
     "        # x= list of feature maps: x=[x[0],...,x[N-1]], in our case N= num_detection_heads=3\n",
     "        #                          each having shape [bs,ch,w,h]\n",
     "        #    each feature map x[i] gives output[i] = w*h anchor coordinates + w*h stride values\n",


### PR DESCRIPTION
when model is set to .eval(), wrong x would be passed to the function and it would throw an error.